### PR TITLE
Minor refactoring for follows

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -68,8 +68,7 @@ class UsersController < ApplicationController
     end
 
     def load_follows
-      @followable_types = @user.follows.pluck(:followable_type).uniq
-      @follows = @user.follows
+      @follows = @user.follows.group_by(&:followable_type)
     end
 
     def valid_access?

--- a/app/helpers/follows_helper.rb
+++ b/app/helpers/follows_helper.rb
@@ -62,8 +62,16 @@ module FollowsHelper
     }.invert[entity]
   end
 
-  def entity_partial(class_name)
-    class_name.parameterize.gsub('-','_')
+  def entity_class_name(followable)
+    followable.class.to_s.parameterize.gsub('-','_')
+  end
+
+  def render_follow(follow)
+    followable = follow.followable
+    partial = entity_class_name(followable)
+    locals = {entity_class_name(followable).to_sym => followable}
+  
+    render partial, locals
   end
 
   private

--- a/app/views/users/_following.html.erb
+++ b/app/views/users/_following.html.erb
@@ -1,6 +1,6 @@
 <ul class="accordion" data-accordion data-allow-all-closed="true">
 
-  <% @followable_types.each do |followable_type| %>
+  <% @follows.each do |followable_type, follows| %>
 
     <li class="accordion-item" data-accordion-item>
 
@@ -16,9 +16,8 @@
       <div class="accordion-content" data-tab-content>
         <table>
           <tbody>
-            <% @follows.where(followable_type: followable_type).each do |follow| %>
-              <%= render entity_partial(followable_type),
-                         entity_partial(followable_type).to_sym => follow.followable %>
+            <% follows.each do |follow| %>
+              <%= render_follow(follow) %>
             <% end %>
           </tbody>
         </table>


### PR DESCRIPTION
Where
=====
* **Related PR's:** consul#1750

What
====
- Refactors `follow` partial rendering

Why
===
- The use of `where` in a view is not a good practice
- The rendering of the partial was a little complicated to understand at first sight

How
===
- Grouping `follows` by `followable_type`
- Adding a helper to render the `follow` partial

Inspiration
===
http://railscasts.com/episodes/407-activity-feed-from-scratch
