### PR TITLE
Manage settings for old and new installations

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,7 +45,7 @@ namespace :deploy do
   #before :starting, "rvm1:install:ruby" # install Ruby and create gemset
   #before :starting, "install_bundler_gem" # install bundler gem
 
-  after "deploy:migrate", "add_new_settings"
+  after "deploy:migrate", "manage_settings"
   after :publishing, "deploy:restart"
   after :published, "delayed_job:restart"
   after :published, "refresh_sitemap"
@@ -55,7 +55,7 @@ namespace :deploy do
 
   desc "Deploys and runs the tasks needed to upgrade to a new release"
   task :upgrade do
-    after "add_new_settings", "execute_release_tasks"
+    after "manage_settings", "execute_release_tasks"
     invoke "deploy"
   end
 end
@@ -76,11 +76,11 @@ task :refresh_sitemap do
   end
 end
 
-task :add_new_settings do
+task :manage_settings do
   on roles(:db) do
     within release_path do
       with rails_env: fetch(:rails_env) do
-        execute :rake, "settings:add_new_settings"
+        execute :rake, "settings:manage_settings"
       end
     end
   end

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -53,4 +53,7 @@ namespace :settings do
     Setting.add_new_settings
   end
 
+  desc "Manage settings"
+  task manage_settings: [:rename_setting_keys, :add_new_settings]
+
 end


### PR DESCRIPTION
## Objectives
The objective of this PR is to give consistency to the management of Settings for both old and new installations.

Nowadays it seems that in each deploy the new settings keys added in the class method of Settings 'defaults' were created.
But when we then executed the 'rename_settings_keys' task manually, the new key was already created and only the old key was deleted, but its value was not copied and therefore it was lost.

When renaming an existing key, we want the possible value of the old key to be saved in the new (renamed) key after each deploy.
For this you have to execute the task rake :rename_setting_keys (to be able to save the value correctly) and then add the new keys (where will also be the new renamed key for new installations).
In this way, the old value of the key, which could have been updated each installation, is not lost.
