### PR TITLE
Ciudades abiertas/advanced configuration section

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -8,7 +8,7 @@ class Admin::SettingsController < Admin::BaseController
                 :poster_feature_short_title_setting, :poster_feature_description_setting
 
   def index
-    @settings_groups = ["configuration", "process", "feature", "map", "uploads", "proposals", "remote_census", "social"].freeze
+    @settings_groups = ["configuration", "process", "feature", "map", "uploads", "proposals", "remote_census", "social", "advanced"].freeze
   end
 
   def update

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -58,7 +58,7 @@ class Admin::SettingsController < Admin::BaseController
       when "social"
         [all_settings["social.facebook"]] + [all_settings["social.twitter"]] + [all_settings["social.google"]]
       when "advanced"
-        [all_settings["advanced.auth"]]
+        [all_settings["advanced.auth"]] + [all_settings["advanced.tracking"]]
       else
         all_settings[group]
       end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -57,6 +57,8 @@ class Admin::SettingsController < Admin::BaseController
         [all_settings["remote_census.general"]] + [all_settings["remote_census.request"]] + [all_settings["remote_census.response"]]
       when "social"
         [all_settings["social.facebook"]] + [all_settings["social.twitter"]] + [all_settings["social.google"]]
+      when "advanced"
+        [all_settings["advanced.auth"]]
       else
         all_settings[group]
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,13 @@ class ApplicationController < ActionController::Base
 
     def authenticate_http_basic
       authenticate_or_request_with_http_basic do |username, password|
-        username == Rails.application.secrets.http_basic_username && password == Rails.application.secrets.http_basic_password
+        username == Retrocompatibility.calculate_value("advanced.auth.http_basic_username", "http_basic_username") &&
+        password == Retrocompatibility.calculate_value("advanced.auth.http_basic_password", "http_basic_password")
       end
     end
 
     def http_basic_auth_site?
-      Rails.application.secrets.http_basic_auth
+      Retrocompatibility.calculate_value("advanced.auth.http_basic_auth", "http_basic_auth")
     end
 
     def verify_lock

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -13,4 +13,12 @@ module SettingsHelper
     key.first == "social" && key.last == "login"
   end
 
+  def advanced_feature?(setting)
+    key = setting.key.split(".")
+    key.first == "advanced" && key.last == "http_basic_auth"
+  end
+
+  def is_feature?(setting)
+    social_feature?(setting) || advanced_feature?(setting)
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -143,6 +143,7 @@ class Setting < ApplicationRecord
         "advanced.auth.http_basic_auth": nil,
         "advanced.auth.http_basic_username": nil,
         "advanced.auth.http_basic_password": nil,
+        "advanced.tracking.rollbar_server_token": nil,
         # Names for the moderation console, as a hint for moderators
         # to know better how to assign users with official positions
         "official_level_1_name": I18n.t("seeds.settings.official_level_1_name"),

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -140,6 +140,9 @@ class Setting < ApplicationRecord
         "uploads.documents.max_amount": 3,
         "uploads.documents.max_size": 3,
         "uploads.documents.content_types": "application/pdf",
+        "advanced.auth.http_basic_auth": nil,
+        "advanced.auth.http_basic_username": nil,
+        "advanced.auth.http_basic_password": nil,
         # Names for the moderation console, as a hint for moderators
         # to know better how to assign users with official positions
         "official_level_1_name": I18n.t("seeds.settings.official_level_1_name"),

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -10,7 +10,7 @@ class Setting < ApplicationRecord
   def type
     if %w[feature process proposals map html homepage uploads].include? prefix
       prefix
-    elsif %w[remote_census social].include? prefix
+    elsif %w[remote_census social advanced].include? prefix
       key.rpartition(".").first
     else
       "configuration"

--- a/app/views/admin/settings/_mixed_settings_table.html.erb
+++ b/app/views/admin/settings/_mixed_settings_table.html.erb
@@ -17,7 +17,7 @@
           </span>
         </td>
 
-        <% if social_feature?(setting) %>
+        <% if is_feature?(setting) %>
           <td colspan="2">
             <% if setting.enabled? %>
               <span class="enabled small-6 column">

--- a/app/views/admin/settings/advanced.html.erb
+++ b/app/views/admin/settings/advanced.html.erb
@@ -1,4 +1,4 @@
-<%= back_link_to %>
+<%= back_link_to admin_settings_path %>
 <h2><%= t("admin.settings.index.advanced.title") %></h2>
 
 <% @settings.each do |setting_group| %>

--- a/app/views/admin/settings/advanced.html.erb
+++ b/app/views/admin/settings/advanced.html.erb
@@ -1,0 +1,7 @@
+<%= back_link_to %>
+<h2><%= t("admin.settings.index.advanced.title") %></h2>
+
+<% @settings.each do |setting_group| %>
+  <h3><%= t("admin.settings.index.advanced.#{setting_group.first.key.split(".").second}") %></h3>
+  <%= render "mixed_settings_table", settings: setting_group %>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -216,6 +216,7 @@ ignore_unused:
   - "dashboard.polls.*.submit"
   - "admin.settings.index.remote_census.*"
   - "admin.settings.index.social.*"
+  - "admin.settings.index.advanced.*"
 ####
 ## Exclude these keys from the `i18n-tasks eq-base" report:
 # ignore_eq_base:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1336,6 +1336,10 @@ en:
           facebook: "Facebook"
           twitter: "Twitter"
           google: "Google"
+        advanced:
+          title: "Advanced Configuration"
+          description: "Allow update advanced configuration"
+          auth: "Http basic authentication"
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1340,6 +1340,7 @@ en:
           title: "Advanced Configuration"
           description: "Allow update advanced configuration"
           auth: "Http basic authentication"
+          tracking: "Error tracking"
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -221,3 +221,14 @@ en:
         key_description: "API key to configure the registration via Google"
         secret: "Secret Token Google"
         secret_description: "Secret token to configure the registration via Google"
+    advanced:
+      auth:
+        http_basic_auth: "Http basic authentication"
+        http_basic_auth_description: "Allow Enable/Disable http basic authentication"
+        http_basic_username: "Http basic authentication Username."
+        http_basic_username_description: "Allow set Username. In order to update the User must first disable the Http Basic Authentication, update the User and re-enable the Http Basic Authentication."
+        http_basic_password: "Http basic authentication Password."
+        http_basic_password_description: "Allow set Password. In order to update the Password must first disable the Http Basic Authentication, update the Password and re-enable the Http Basic Authentication."
+      tracking:
+        rollbar_server_token: "Rollbar server token"
+        rollbar_server_token_description: "Rollbar server token Description"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -224,11 +224,11 @@ en:
     advanced:
       auth:
         http_basic_auth: "Http basic authentication"
-        http_basic_auth_description: "Allow Enable/Disable http basic authentication"
+        http_basic_auth_description: "Allow Enable/Disable http basic authentication. In order to enable this field ensure have defined a user and password."
         http_basic_username: "Http basic authentication Username."
         http_basic_username_description: "Allow set Username. In order to update the User must first disable the Http Basic Authentication, update the User and re-enable the Http Basic Authentication."
         http_basic_password: "Http basic authentication Password."
         http_basic_password_description: "Allow set Password. In order to update the Password must first disable the Http Basic Authentication, update the Password and re-enable the Http Basic Authentication."
       tracking:
         rollbar_server_token: "Rollbar server token"
-        rollbar_server_token_description: "Rollbar server token Description"
+        rollbar_server_token_description: "This token will give the application access to your Rollbar account."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1337,6 +1337,10 @@ es:
           facebook: "Facebook"
           twitter: "Twitter"
           google: "Google"
+        advanced:
+          title: "Configuración Avanzada"
+          description: "Permitir actualizar las configuraciones avanzadas"
+          auth: "Autenticación básica por http"
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1341,6 +1341,7 @@ es:
           title: "Configuración Avanzada"
           description: "Permitir actualizar las configuraciones avanzadas"
           auth: "Autenticación básica por http"
+          tracking: "Monitorización de errores"
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -224,11 +224,11 @@ es:
     advanced:
       auth:
         http_basic_auth: "Autenticación básica por http"
-        http_basic_auth_description: "Permitir Activar/Desactivar la autenticación básica por http"
+        http_basic_auth_description: "Permitir Activar/Desactivar la autenticación básica por http. Para habilitar este campo, asegúrese de haber definido un usuario y una contraseña."
         http_basic_username: "Usuario para la autenticación básica por http"
         http_basic_username_description: "Permitir setear el Usuario. Para poder actualizar el Usuario debe deshabilitar primero la Autenticación básica por http, actualizar el Usuario y volver a activar la Autenticación básica por http."
         http_basic_password: "Contraseña para la autenticación básica por http"
         http_basic_password_description: "Permitir setear la Contraseña. Para poder actualizar la Contraseña debe deshabilitar primero la Autenticación básica por http, actualizar la Contraseña y volver a activar la Autenticación básica por http."
       tracking:
-        rollbar_server_token: "Rollbar server token"
-        rollbar_server_token_description: "Rollbar server token Descripción"
+        rollbar_server_token: "Token de acceso a Rollbar"
+        rollbar_server_token_description: "Este token le dará a la aplicación acceso a su cuenta Rollbar."

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -224,8 +224,11 @@ es:
     advanced:
       auth:
         http_basic_auth: "Autenticación básica por http"
-        http_basic_auth_description: "Permitir Activar/Desactivar la autenticación básica po http"
+        http_basic_auth_description: "Permitir Activar/Desactivar la autenticación básica por http"
         http_basic_username: "Usuario para la autenticación básica por http"
         http_basic_username_description: "Permitir setear el Usuario. Para poder actualizar el Usuario debe deshabilitar primero la Autenticación básica por http, actualizar el Usuario y volver a activar la Autenticación básica por http."
         http_basic_password: "Contraseña para la autenticación básica por http"
         http_basic_password_description: "Permitir setear la Contraseña. Para poder actualizar la Contraseña debe deshabilitar primero la Autenticación básica por http, actualizar la Contraseña y volver a activar la Autenticación básica por http."
+      tracking:
+        rollbar_server_token: "Rollbar server token"
+        rollbar_server_token_description: "Rollbar server token Descripción"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -221,3 +221,11 @@ es:
         key_description: "API Key para configurar el registro por Google"
         secret: "Secret Token Google"
         secret_description: "Secret token para configurar el registro por Google"
+    advanced:
+      auth:
+        http_basic_auth: "Autenticación básica por http"
+        http_basic_auth_description: "Permitir Activar/Desactivar la autenticación básica po http"
+        http_basic_username: "Usuario para la autenticación básica por http"
+        http_basic_username_description: "Permitir setear el Usuario. Para poder actualizar el Usuario debe deshabilitar primero la Autenticación básica por http, actualizar el Usuario y volver a activar la Autenticación básica por http."
+        http_basic_password: "Contraseña para la autenticación básica por http"
+        http_basic_password_description: "Permitir setear la Contraseña. Para poder actualizar la Contraseña debe deshabilitar primero la Autenticación básica por http, actualizar la Contraseña y volver a activar la Autenticación básica por http."

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -60,4 +60,11 @@ namespace :settings do
   desc "Manage settings"
   task manage_settings: [:rename_setting_keys, :add_new_settings]
 
+  desc "Copy http basic auth from secrets to settings"
+  task copy_http_basic_auth_to_settings: :environment do
+    Setting["advanced.auth.http_basic_auth"] = Rails.application.secrets["http_basic_auth"]
+    Setting["advanced.auth.http_basic_username"] = Rails.application.secrets["http_basic_username"]
+    Setting["advanced.auth.http_basic_password"] = Rails.application.secrets["http_basic_password"]
+  end
+
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -43,6 +43,10 @@ describe "Admin settings" do
     expect(page).to have_content "Registration with social networks"
     expect(page).to have_content "Allow users to sign up with social networks (Twitter, Facebook, Google)"
     expect(page).to have_link("Configure", href: admin_setting_path("social"))
+
+    expect(page).to have_content "Advanced Configuration"
+    expect(page).to have_content "Allow update advanced configuration"
+    expect(page).to have_link("Configure", href: admin_setting_path("advanced"))
   end
 
   scenario "Update" do


### PR DESCRIPTION
## References
Related Issues: #18 #19 #20 

## Objectives
- Add new advanced configuration section to setting#index.
- Move secrets related with 'rollbar and http auth' to new section 'Advanced Configuration'
  - Rails.application.secrets.rollbar_server_token
  - Rails.application.secrets.http_basic_auth
  - Rails.application.secrets.http_basic_username
  - Rails.application.secrets.http_basic_password
- Backwards compatibility

## Visual Changes
New index section:
![Captura de pantalla 2019-07-29 a las 13 58 56](https://user-images.githubusercontent.com/16189/62046787-1e0b0800-b209-11e9-940b-e9cdddb1a377.png)

Advanced configuration section:
![Captura de pantalla 2019-07-29 a las 13 59 33](https://user-images.githubusercontent.com/16189/62046835-3713b900-b209-11e9-85af-bb912248cc9e.png)

## Notes
The backward compatibility consists of trying to recover always the value of Settings, but in case it is empty we try to recover the value of the Secrets.

⚠️ For existent installations, you can execute next rake task after deploy to copy Secrets values to related Settings: `rake settings:copy_http_basic_auth_to_settings`

