### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1581,7 +1581,8 @@ describe "Admin budget investments" do
       before { selected_bi.update(cached_votes_up: 50) }
 
       scenario "After unselecting an investment", :js do
-        create_list(:budget_investment, 30, budget: budget)
+        allow(Budget::Investment).to receive(:default_per_page).and_return 1
+        create_list(:budget_investment, 2, budget: budget)
 
         visit admin_budget_budget_investments_path(budget)
 


### PR DESCRIPTION
## Objectives
Fix flaky spec: 
Stub default per page value to 1, to avoid having to create 30 Budget Investments.

When execute this line: `click_link("Next")` with 30 Budget Investments, too many times I didn't have time to load `expect(page).to have_link("Previous")`.
