### PR TITLE
Fix scroll and active button

### DIFF
--- a/app/assets/javascripts/foundation_extras.js
+++ b/app/assets/javascripts/foundation_extras.js
@@ -17,6 +17,9 @@
       $(window).trigger("resize");
       $(document).on("page:before-unload", this.clearSticky);
       window.addEventListener("popstate", this.clearSticky, false);
+      $("#side_menu ul").on("down.zf.accordionMenu", function(e) {
+        Foundation.reInit($("[data-equalizer]"));
+      });
       $(function() {
         if ($(window).width() < 620) {
           App.FoundationExtras.mobile_ui_init();

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="admin-sidebar" data-equalizer-watch>
-  <ul id="admin_menu" data-accordion-menu data-multi-open="false">
+  <ul id="admin_menu" data-accordion-menu>
     <% if feature?(:proposals) %>
       <li class="section-title">
         <%= link_to admin_proposals_path do %>


### PR DESCRIPTION
## References
None

## Objectives
- [x] Sidemenu: Active button when the dropdown is open and close.
- [x] Sidemenu: After clicking the button in the navbar, the scroll in the sidemenu returns to work.

## Visual Changes
**Before**
*active button*
![btn-active-berfore](https://user-images.githubusercontent.com/1497150/65760534-800abf80-e11d-11e9-9e80-327ac060ce94.gif)

**Scroll**
![scroll-before](https://user-images.githubusercontent.com/1497150/65760952-3bcbef00-e11e-11e9-8eb0-1afb0e4d7032.gif)

**After**
*active button*
![btn-active](https://user-images.githubusercontent.com/1497150/65760280-007cf080-e11d-11e9-9372-9f678ce4f3bd.gif)

*Scroll*
![scrollll](https://user-images.githubusercontent.com/1497150/65761288-cc0a3400-e11e-11e9-8a00-74fb648c7788.gif)


## Notes
None