### PR TITLE
Sms configuration section

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -8,7 +8,7 @@ class Admin::SettingsController < Admin::BaseController
                 :poster_feature_short_title_setting, :poster_feature_description_setting
 
   def index
-    @settings_groups = ["configuration", "process", "feature", "map", "uploads", "proposals", "remote_census", "social", "advanced", "smtp", "regional"].freeze
+    @settings_groups = ["configuration", "process", "feature", "map", "uploads", "proposals", "remote_census", "social", "advanced", "smtp", "regional", "sms"].freeze
   end
 
   def update

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -235,7 +235,10 @@ class Setting < ApplicationRecord
         "remote_census.response.gender": "",
         "remote_census.response.name": "",
         "remote_census.response.surname": "",
-        "remote_census.response.valid": ""
+        "remote_census.response.valid": "",
+        "sms.endpoint": nil,
+        "sms.username": nil,
+        "sms.password": nil
       }
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,7 @@ class Setting < ApplicationRecord
   end
 
   def type
-    if %w[feature process proposals map html homepage uploads smtp].include? prefix
+    if %w[feature process proposals map html homepage uploads smtp sms].include? prefix
       prefix
     elsif %w[remote_census social advanced regional].include? prefix
       key.rpartition(".").first

--- a/app/views/admin/settings/sms.html.erb
+++ b/app/views/admin/settings/sms.html.erb
@@ -1,0 +1,4 @@
+<%= back_link_to admin_settings_path %>
+<h2><%= t("admin.settings.index.sms.title") %></h2>
+
+<%= render "settings_table", settings: @settings %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1347,6 +1347,9 @@ en:
           default_locale: "Application default locale"
           available_locale: "Application available locales"
           timezone: "Time Zone"
+        sms:
+          title: SMS Configuration
+          description: "Set SMS configuration to send sms for verification users."
       setting: Feature
       setting_actions: Actions
       setting_name: Setting

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -311,3 +311,10 @@ en:
       time_zone:
         key: "Time Zone"
         key_description: "Define the Time Zone of the application"
+    sms:
+      endpoint: "SMS endpoint"
+      endpoint_description: "Host name where the sms service is available"
+      username: "SMS service username"
+      username_description: "Allow set username"
+      password: "SMS service password"
+      password_description: "Allow set password"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1348,6 +1348,9 @@ es:
           default_locale: "Idioma por defecto de la aplicación"
           available_locale: "Idiomas disponibles de la aplicación"
           timezone: "Zona horaria"
+        sms:
+          title: Configuración SMS
+          description: "Configurar las credenciales del servicio SMS para el envio de sms para verificar un usuario."
       setting: Funcionalidad
       setting_actions: Acciones
       setting_name: Configuración

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -311,3 +311,10 @@ es:
       time_zone:
         key: "Zona horaria"
         key_description: "Selecciona la zona horaria de la aplicación"
+    sms:
+      endpoint: "SMS endpoint"
+      endpoint_description: "Nombre del host donde se encuentra el servicio de SMS"
+      username: "Usuario para el servicio de SMS"
+      username_description: "Permitir setear el usuario"
+      password: "Password para el servicio de SMS"
+      password_description: "Permitir setear el password"

--- a/lib/sms_api.rb
+++ b/lib/sms_api.rb
@@ -8,11 +8,11 @@ class SMSApi
 
   def url
     return "" unless end_point_available?
-    open(Rails.application.secrets.sms_end_point).base_uri.to_s
+    open(Retrocompatibility.calculate_value("sms.endpoint", "sms_end_point")).base_uri.to_s
   end
 
   def authorization
-    Base64.encode64("#{Rails.application.secrets.sms_username}:#{Rails.application.secrets.sms_password}")
+    Base64.encode64("#{Retrocompatibility.calculate_value("sms.username", "sms_username")}:#{Retrocompatibility.calculate_value("sms.password", "sms_password")}")
   end
 
   def sms_deliver(phone, code)

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -83,4 +83,11 @@ namespace :settings do
     end
   end
 
+  desc "Copy sms api configuration from secrets to settings"
+  task copy_sms_configuration_to_settings: :environment do
+    Setting["sms.endpoint"] = Rails.application.secrets["sms_end_point"]
+    Setting["sms.username"] = Rails.application.secrets["sms_username"]
+    Setting["sms.password"] = Rails.application.secrets["sms_password"]
+  end
+
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -55,6 +55,10 @@ describe "Admin settings" do
     expect(page).to have_content "Languages and Time Zone"
     expect(page).to have_content "Set default locale, available locales and time zone"
     expect(page).to have_link("Configure", href: admin_setting_path("regional"))
+
+    expect(page).to have_content "SMS Configuration"
+    expect(page).to have_content "Set SMS configuration to send sms for verification users."
+    expect(page).to have_link("Configure", href: admin_setting_path("sms"))
   end
 
   scenario "Update" do


### PR DESCRIPTION
## References
Related Issues: #18 #19 #20  

## Objectives
- Add new sms configuration section to setting#index.
- Move secrets related with 'sms API' to new section 'SMS Configuration'
  - Rails.application.secrets.sms_end_point
  - Rails.application.secrets.sms_username
  - Rails.application.secrets.sms_password
- Backwards compatibility

## Visual Changes
New index section:
![Captura de pantalla 2019-10-05 a las 19 00 48](https://user-images.githubusercontent.com/16189/66258200-80046280-e7a2-11e9-8a0a-784f762c5b35.png)

SMS configuration section:
![Captura de pantalla 2019-10-05 a las 19 01 04](https://user-images.githubusercontent.com/16189/66258205-87c40700-e7a2-11e9-9b05-5708c6de3a43.png)


## Notes
The backward compatibility consists of trying to recover always the value of Settings, but in case it is empty we try to recover the value of the Secrets.

⚠️ For existent installations, you can execute next rake task after deploy to copy Secrets values to related Settings: `rake settings:copy_sms_configuration_to_settings`
