### PR TITLE
[WIP] Improve remote translations

### DIFF
--- a/app/controllers/concerns/remotely_translatable.rb
+++ b/app/controllers/concerns/remotely_translatable.rb
@@ -2,7 +2,7 @@ module RemotelyTranslatable
   private
 
     def detect_remote_translations(*args)
-      return [] unless Setting["feature.remote_translations"].present?
+      return [] unless Setting["feature.remote_translations"].present? && api_key_has_been_set_in_secrets?
 
       resources_groups(*args).flatten.select { |resource| translation_empty?(resource) }.map do |resource|
         remote_translation_for(resource)
@@ -23,5 +23,9 @@ module RemotelyTranslatable
       feeds = args.find { |arg| arg&.first.class == Widget::Feed } || []
 
       args.compact - [feeds] + feeds.map(&:items)
+    end
+
+    def api_key_has_been_set_in_secrets?
+      Rails.application.secrets.microsoft_api_key.present?
     end
 end

--- a/app/controllers/concerns/remotely_translatable.rb
+++ b/app/controllers/concerns/remotely_translatable.rb
@@ -16,7 +16,7 @@ module RemotelyTranslatable
     end
 
     def translation_empty?(resource)
-      resource.translations.where(locale: I18n.locale).empty?
+      resource.class.translates? && resource.translations.where(locale: I18n.locale).empty?
     end
 
     def resources_groups(*args)

--- a/app/models/remote_translation.rb
+++ b/app/models/remote_translation.rb
@@ -4,7 +4,8 @@ class RemoteTranslation < ApplicationRecord
   validates :remote_translatable_id, presence: true
   validates :remote_translatable_type, presence: true
   validates :locale, presence: true
-
+  validates :locale, inclusion: { in: RemoteTranslations::Microsoft::AvailableLocales.available_locales }
+  validate :already_translated_resource
   after_create :enqueue_remote_translation
 
   def enqueue_remote_translation
@@ -16,5 +17,11 @@ class RemoteTranslation < ApplicationRecord
           remote_translatable_type: remote_translation["remote_translatable_type"],
           locale: remote_translation["locale"],
           error_message: nil).any?
+  end
+
+  def already_translated_resource
+    if remote_translatable&.translations&.where(locale: locale).present?
+      errors.add(:locale, :already_translated)
+    end
   end
 end

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -548,6 +548,10 @@ en:
           attributes:
             valuation:
               cannot_comment_valuation: "You cannot comment a valuation"
+        remote_translation:
+          attributes:
+            locale:
+              already_translated: Already translated resource
       messages:
         translations_too_short: Is mandatory to provide one translation at least
         record_invalid: "Validation failed: %{errors}"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -550,6 +550,10 @@ es:
           attributes:
             valuation:
               cannot_comment_valuation: "No puedes comentar una evaluación"
+        remote_translation:
+          attributes:
+            locale:
+              already_translated: Recurso ya traducido
       messages:
         translations_too_short: El obligatorio proporcionar una traducción como mínimo
         record_invalid: "Error de validación: %{errors}"

--- a/spec/controllers/concerns/remotely_translatable_spec.rb
+++ b/spec/controllers/concerns/remotely_translatable_spec.rb
@@ -4,6 +4,7 @@ include RemotelyTranslatable
 describe RemotelyTranslatable do
   before do
     Setting["feature.remote_translations"] = true
+    allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return("123")
   end
 
   describe "#detect_remote_translations" do
@@ -45,6 +46,16 @@ describe RemotelyTranslatable do
         I18n.with_locale(:es) do
           expect(detect_remote_translations(widget_feeds).count).to eq 9
         end
+      end
+    end
+
+    it "When api key has not been set in secrets should not detect remote_translations" do
+      allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return(nil)
+      proposal = create(:proposal)
+      comment = create(:comment, commentable: proposal)
+
+      I18n.with_locale(:es) do
+        expect(detect_remote_translations([proposal, comment])).to eq []
       end
     end
 

--- a/spec/controllers/concerns/remotely_translatable_spec.rb
+++ b/spec/controllers/concerns/remotely_translatable_spec.rb
@@ -65,5 +65,13 @@ describe RemotelyTranslatable do
 
       expect(detect_remote_translations([proposal, comment])).to eq []
     end
+
+    it "When resource class is not translatable should not detect remote_translations" do
+      legislation_proposal = create(:legislation_proposal)
+
+      I18n.with_locale(:es) do
+        expect(detect_remote_translations([legislation_proposal])).to eq []
+      end
+    end
   end
 end

--- a/spec/features/remote_translations_spec.rb
+++ b/spec/features/remote_translations_spec.rb
@@ -7,6 +7,7 @@ describe "Remote Translations" do
     available_locales_response = %w[de en es fr pt zh-Hans]
     expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).
                                                             and_return(available_locales_response)
+    allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return("123")
   end
 
   describe "Display remote translation button when locale is included in microsoft translate client" do

--- a/spec/features/remote_translations_spec.rb
+++ b/spec/features/remote_translations_spec.rb
@@ -32,20 +32,20 @@ describe "Remote Translations" do
       end
     end
 
-    context "with locale that has :en fallback" do
+    context "with locale that has :es fallback" do
       before do
         allow(I18n.fallbacks).to receive(:[]).and_return([:es])
         Globalize.set_fallbacks_to_all_available_locales
       end
 
-      scenario "with locale that has :es fallback" do
+      scenario "should display text in Spanish" do
         visit root_path(locale: :fr)
 
         expect(page).to have_css ".remote-translations-button"
         expect(page).to have_content "El contenido de esta página no está disponible en tu idioma"
       end
 
-      scenario "with locale that has :es fallback and need parse key" do
+      scenario "should display text in Spanish after parse key" do
         visit root_path(locale: :"pt-BR")
 
         expect(page).to have_css ".remote-translations-button"

--- a/spec/features/remote_translations_spec.rb
+++ b/spec/features/remote_translations_spec.rb
@@ -5,7 +5,7 @@ describe "Remote Translations" do
     Setting["feature.remote_translations"] = true
     create(:proposal)
     available_locales_response = %w[de en es fr pt zh-Hans]
-    expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).
+    expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).at_most(2).times.
                                                             and_return(available_locales_response)
     allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return("123")
   end

--- a/spec/models/remote_translation_spec.rb
+++ b/spec/models/remote_translation_spec.rb
@@ -27,6 +27,16 @@ describe RemoteTranslation do
     expect(remote_translation).not_to be_valid
   end
 
+  it "is not valid without an available_locales" do
+    remote_translation.locale = "unavailable_locale"
+    expect(remote_translation).not_to be_valid
+  end
+
+  it "is not valid when exists a translation for locale" do
+    remote_translation.locale = :en
+    expect(remote_translation).not_to be_valid
+  end
+
   describe "#enqueue_remote_translation", :delay_jobs do
     it "after create enqueue Delayed Job" do
       expect { remote_translation.save }.to change { Delayed::Job.count }.by(1)

--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -10,7 +10,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
   before do
     Setting["feature.remote_translations"] = true
     available_locales_response = %w[de en es fr pt zh-Hans]
-    expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).at_most(3).times.
+    expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).at_most(4).times.
                                                             and_return(available_locales_response)
     allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return("123")
   end

--- a/spec/shared/features/remotely_translatable.rb
+++ b/spec/shared/features/remotely_translatable.rb
@@ -12,6 +12,7 @@ shared_examples "remotely_translatable" do |factory_name, path_name, path_argume
     available_locales_response = %w[de en es fr pt zh-Hans]
     expect(RemoteTranslations::Microsoft::AvailableLocales).to receive(:available_locales).at_most(3).times.
                                                             and_return(available_locales_response)
+    allow(Rails.application.secrets).to receive(:microsoft_api_key).and_return("123")
   end
 
   context "Button to request remote translation" do


### PR DESCRIPTION
## References
Related PR's: 
- [Translate user generated content #3359](https://github.com/consul/consul/pull/3359)
- [Update remote translations docs with create alert section #91](https://github.com/consul/docs/pull/91)

## Objectives
- Prevent massive requests from a single IP ([gem rack-attack](https://github.com/kickstarter/rack-attack)) to the remote translation service to avoid exorbitant charges to the institution offering the service. In the end, not only has the rack-attack been configured for requests to RemoteTranslations but also for any other type of request to the application.
- Avoid curl requests to the application by requesting unavailable languages.
- Avoid curl requests to the application by requesting resources already translated 

## Visual Changes
None

## Notes
Rack attack has been configured to block from 60 requests per minute.
