### PR TITLE
Install and configure Twilio to send SMS text messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem "view_component", "~> 2.19.1", require: "view_component/engine"
 gem "whenever", "~> 1.0.0", require: false
 gem "wicked_pdf", "~> 2.1.0"
 gem "wkhtmltopdf-binary", "~> 0.12.4"
+gem "twilio-ruby"
 
 source "https://rails-assets.org" do
   gem "rails-assets-leaflet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,6 +600,10 @@ GEM
       rack (>= 1.3, < 3)
       rack-accept (~> 0.4)
       tilt (>= 1.4, < 3)
+    twilio-ruby (5.44.0)
+      faraday (>= 0.9, < 2.0)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -730,6 +734,7 @@ DEPENDENCIES
   translator-text (~> 0.1.0)
   turbolinks (~> 5.2.1)
   turnout (~> 2.5.0)
+  twilio-ruby
   uglifier (~> 4.2.0)
   view_component (~> 2.19.1)
   web-console (~> 3.7.0)

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -12,9 +12,9 @@ apis: &apis
   census_api_institution_code: ""
   census_api_portal_name: ""
   census_api_user_code: ""
-  sms_end_point:  ""
-  sms_username: ""
-  sms_password: ""
+  sms_account_sid: ""
+  sms_auth_token: ""
+  sms_phone_number: ""
 
 http_basic_auth: &http_basic_auth
   http_basic_auth: true


### PR DESCRIPTION
## Objectives
Update SMSApi to allow CONSUL to send SMS messages through Twilio REST API.

Twilio docs: https://community.consulproject.org/t/sms-setup-for-consul/723/2?u=sendero

## Notes
**Pending to add specs and to test on a production environment.**
